### PR TITLE
Lager 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@
 {lager_nt_eventlog_backend, [Source, Level, {Formatter, FormatConfig}]}
 ```
   
-  `Formatter` is an atom of a module the implements `format/2` and `format/3` callbacks.
-  if a formatter is not specified, the `lager_default_formatter` will be used by default.
+  `Formatter` is an atom of a module that implements the `format(lager_msg:lager_msg(),list()) -> any()` callback.
   
-  `FormatConfig` is an iolist that the `Formatter` uses to construct the message.
-  if a formatter is not specified, the following is used to construct log messages similar to Lager 1.0
+  `FormatConfig` is an iolist of instructions that the `Formatter` uses to construct the message.
+  Refer to Lager's [documentation](https://github.com/basho/lager#custom-formatting) for specific options.
+  
+  When the formatter tuple is not specified, the module `lager_default_formatter` and the following format 
+  config will be used by default to construct log messages similar to Lager 1.0
   
 ```erlang
 [

--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@
 {lager_nt_eventlog_backend, ["product", info]}
 ```
 
+## Custom Formatting
+  A custom formatter can be supplied via the configuration:
+  
+```erlang
+{lager_nt_eventlog_backend, [Source, Level, {Formatter, FormatConfig}]}
+```
+  
+  `Formatter` is an atom of a module the implements `format/2` and `format/3` callbacks.
+  if a formatter is not specified, the `lager_default_formatter` will be used by default.
+  
+  `FormatConfig` is an iolist that the `Formatter` uses to construct the message.
+  if a formatter is not specified, the following is used to construct log messages similar to Lager 1.0
+  
+```erlang
+[
+  {pid, ""},
+  {module, [
+    {pid, ["@"], ""},
+    module,
+    {function, [":", function], ""},
+    {line, [":",line], ""}], ""},
+  " ",
+  message
+]
+```
+
   Refer to Lager's documentation for futher information on configuring handlers.
 
 # THANKS

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-   {lager, "1.0.*", {git, "git://github.com/basho/lager", {branch, "master"}}}
+   {lager, "((3|2)\\.|1\\.0|1\\.2).*", {git, "git://github.com/basho/lager", {branch, "master"}}}
 ]}.
 
 %% Port-driver / NIF compiler setup for MSVC

--- a/src/lager_nt_eventlog.app.src
+++ b/src/lager_nt_eventlog.app.src
@@ -3,7 +3,7 @@
 {application, lager_nt_eventlog,
  [
   {description, "NT Event Log backend for Lager"},
-  {vsn, "0.9.0"},
+  {vsn, "1.0.0"},
   {modules, []},
   {applications, [
                   kernel,

--- a/src/lager_nt_eventlog_backend.erl
+++ b/src/lager_nt_eventlog_backend.erl
@@ -7,17 +7,21 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
 
--record(state, {handle, level}).
+-record(state, {handle, level, formatter, format_config}).
 
 -define(DEFAULT_FORMAT, [{pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":",line], ""}], ""}, " ", message]).
 -include_lib("lager/include/lager.hrl").
 
 %% @private
 init([Source, Level]) ->
+    init([Source, Level, {lager_default_formatter, ?DEFAULT_FORMAT}]);
+init([Source, Level, {Formatter, FormatterConfig}]) ->
     case nt_eventlog:register_event_source(Source) of
         {ok, Handle} ->
             {ok, #state{level=lager_util:level_to_num(Level),
-                        handle = Handle}};
+                        handle = Handle,
+                        formatter = Formatter,
+                        format_config = FormatterConfig}};
         Error ->
             Error
     end.
@@ -35,10 +39,10 @@ handle_event({log, Level, {_Date, _Time}, [_LevelStr, Location, Message]},
     #state{handle = Handle, level = LogLevel} = State) when Level =< LogLevel ->
     nt_eventlog:report_event(Handle, Level, lists:flatten([Location, Message])),
     {ok, State};
-handle_event({log, Message}, #state{handle = Handle, level=Level} = State) ->
+handle_event({log, Message}, #state{handle = Handle, level = Level, formatter = Formatter, format_config = FormatConfig} = State) ->
     case lager_util:is_loggable(Message, Level, ?MODULE) of
         true ->
-            nt_eventlog:report_event(Handle, Level, lager_default_formatter:format(Message, ?DEFAULT_FORMAT)),
+            nt_eventlog:report_event(Handle, Level, Formatter:format(Message, FormatConfig)),
             {ok, State};
         false ->
             {ok, State}
@@ -55,5 +59,7 @@ terminate(_Reason, #state{handle = Handle}) ->
     nt_eventlog:deregister_event_source(Handle).
 
 %% @private
+code_change("0.9.0", {state, Handle, Level}, _Extra) ->
+    {ok, #state{handle = Handle, level = Level, format_config = lager_default_formatter, format_config = ?DEFAULT_FORMAT }};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/src/lager_nt_eventlog_backend.erl
+++ b/src/lager_nt_eventlog_backend.erl
@@ -71,7 +71,7 @@ terminate(_Reason, #state{handle = Handle}) ->
 
 %% @private
 code_change("0.9.0", {state, Handle, Level}, _Extra) ->
-    {ok, #state{id = ?MODULE, handle = Handle, level = Level, format_config = lager_default_formatter, format_config = ?DEFAULT_FORMAT }};
+    {ok, #state{id = ?MODULE, handle = Handle, level = Level, formatter = lager_default_formatter, format_config = ?DEFAULT_FORMAT }};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 

--- a/src/lager_nt_eventlog_backend.erl
+++ b/src/lager_nt_eventlog_backend.erl
@@ -80,22 +80,22 @@ config_to_id([Source | _]) ->
 
 %% @private
 parse_level(Level) ->
-    case parse_level(Level, 2) of
+    case parse_level_to_mask(Level) of
         {error, _} ->
-            parse_level(Level, 1);
+            parse_level_to_num(Level);
         Mask ->
             Mask
     end.
 
-parse_level(Level, 2) ->
+parse_level_to_mask(Level) ->
     try lager_util:config_to_mask(Level) of
         Res ->
             {ok, Res}
     catch
         _:_ ->
             {error, bad_log_level}
-    end;
-parse_level(Level, 1) ->
+    end.
+parse_level_to_num(Level) ->
     try lager_util:level_to_num(Level) of
         Res ->
             {ok, Res}


### PR DESCRIPTION
Update the backend to be compatible with the Lager 2.0 Backend API changes.
- uses new lager formatter to allow customization of the log message
- compatible with Syslog style log level comparison flags
- implements lager config_to_id callback to enable create gen_event handler id based on eventlog source
